### PR TITLE
Fix: Update Endpoint

### DIFF
--- a/dto/task.go
+++ b/dto/task.go
@@ -12,7 +12,7 @@ type TaskRequest struct {
 
 type TaskUpdate struct {
 	Description string    `json:"description" binding:"omitempty,min=5"`
-	Completed   bool      `json:"completed"`
+	Completed   *bool     `json:"completed"`
 	StartDate   time.Time `json:"startDate"`
 	Deadline    time.Time `json:"deadline"`
 	UpdatedBy   *string   `json:"updatedBy"`

--- a/helper/coalesce.go
+++ b/helper/coalesce.go
@@ -1,0 +1,31 @@
+package helper
+
+import "time"
+
+func CoalesceInt(newValue, oldValue int) int {
+	if newValue != 0 {
+		return newValue
+	}
+	return oldValue
+}
+
+func CoalesceString(newValue, oldValue string) string {
+	if newValue != "" {
+		return newValue
+	}
+	return oldValue
+}
+
+func CoalesceBoolPtr(newValue, oldValue *bool) *bool {
+	if newValue != nil {
+		return newValue
+	}
+	return oldValue
+}
+
+func CoalesceTime(newValue, oldValue time.Time) time.Time {
+	if !newValue.IsZero() {
+		return newValue
+	}
+	return oldValue
+}

--- a/model/task.go
+++ b/model/task.go
@@ -15,3 +15,17 @@ type Task struct {
 	UpdatedAt   *time.Time `json:"updatedAt"`
 	UpdatedBy   *string    `json:"updatedBy"`
 }
+
+type TaskUpdate struct {
+	Id          int        `json:"id"`
+	Uuid        string     `json:"uuid"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Completed   *bool      `json:"completed"`
+	StartDate   time.Time  `json:"startDate"`
+	Deadline    time.Time  `json:"deadline"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	CreatedBy   string     `json:"createdBy"`
+	UpdatedAt   *time.Time `json:"updatedAt"`
+	UpdatedBy   *string    `json:"updatedBy"`
+}

--- a/repository/task.go
+++ b/repository/task.go
@@ -135,13 +135,13 @@ func (r *TaskRepository) GetTaskByUuid(uuid string) (result *model.Task, err err
 	return &task, nil
 }
 
-func (r *TaskRepository) UpdateTask(params *model.Task) (err error) {
+func (r *TaskRepository) UpdateTask(params *model.TaskUpdate) (err error) {
 	// Query untuk memperbarui task berdasarkan Uuid
 	const query = `UPDATE public.tasks SET
-						description = COALESCE($2, description),
-						completed = COALESCE($3, completed),
-						start_date = COALESCE($4, start_date),
-						deadline = COALESCE($5, deadline),
+						description = $2,
+						completed = $3,
+						start_date = $4,
+						deadline = $5,
 						updated_at = $6,
 						updated_by = $7
 					WHERE uuid = $1`

--- a/service/task.go
+++ b/service/task.go
@@ -77,19 +77,18 @@ func (s *TaskService) GetTaskByUuid(uuid string) (result *dto.TaskResponse, err 
 
 func (s *TaskService) UpdateTask(uuid string, params dto.TaskUpdate) (err error) {
 	// Find the task by Uuid
-	_, err = s.repository.GetTaskByUuid(uuid)
+	details, err := s.repository.GetTaskByUuid(uuid)
 	if err != nil {
 		return err
 	}
 
 	now := time.Now()
-
-	updateValue := &model.Task{
+	updateValue := &model.TaskUpdate{
 		Uuid:        uuid,
-		Description: params.Description,
-		Completed:   params.Completed,
-		StartDate:   params.StartDate,
-		Deadline:    params.Deadline,
+		Description: helper.CoalesceString(params.Description, details.Description),
+		Completed:   helper.CoalesceBoolPtr(params.Completed, &details.Completed),
+		StartDate:   helper.CoalesceTime(params.StartDate, details.StartDate),
+		Deadline:    helper.CoalesceTime(params.Deadline, details.Deadline),
 		UpdatedAt:   &now,
 		UpdatedBy:   params.UpdatedBy,
 	}


### PR DESCRIPTION
This PR addresses an issue with the PATCH endpoint where, if no value is sent for a field, it is set incorrectly to empty or null. The endpoint has been updated to ensure that fields not included in the request retain their existing values in the database, as expected for a PATCH operation.

This fix ensures that only the fields explicitly provided in the request are updated, while others remain unchanged.